### PR TITLE
Move mangle to go 1.18 to improve portability

### DIFF
--- a/analysis/validation.go
+++ b/analysis/validation.go
@@ -17,11 +17,11 @@
 package analysis
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	"go.uber.org/multierr"
 	"github.com/google/mangle/ast"
 	"github.com/google/mangle/builtin"
 	"github.com/google/mangle/functional"
@@ -237,7 +237,7 @@ func (a *Analyzer) Analyze(program []ast.Clause) (*ProgramInfo, error) {
 	for p, d := range a.decl {
 		globalDecls[p] = d
 		if errs := CheckDecl(d); errs != nil {
-			return nil, errors.Join(errs...)
+			return nil, multierr.Combine(errs...)
 		}
 	}
 	desugaredDecls, err := symbols.CheckAndDesugar(globalDecls)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/mangle
 
-go 1.20
+go 1.18
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.9


### PR DESCRIPTION
I need it to work with go 1.18.